### PR TITLE
Remove URL scheme from description for addr flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func configureRootCommand() *cobra.Command {
 		"addr",
 		"a",
 		"",
-		"the address of the opentsdb server, should be of the form 'http://host:port'")
+		"the address of the opentsdb server, should be of the form 'host:port'")
 
 	_ = cmd.MarkFlagRequired("addr")
 


### PR DESCRIPTION
In my testing providing a `http://` prefixed URL as the argument for `--addr` flag resulted in an error: 

```
The target OpenTSDB is unreachable: dial tcp: addres
s http://127.0.0.1:4242: too many colons in address\n
```

With this change the flag description is corrected for the current implementation.